### PR TITLE
Mise à jour des dépendances

### DIFF
--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -16,9 +16,9 @@ releaseLabel: working
 jurisdiction: urn:iso:std:iso:3166#FR "FRANCE"
 
 dependencies:
-  ans.fhir.fr.annuaire: 1.0.1
-  hl7.fhir.fr.core: 2.0.1
-  ans.fr.nos: latest
+  ans.fhir.fr.annuaire: 1.1.0
+  hl7.fhir.fr.core: 2.1.0
+  ans.fr.terminologies: latest
 
 parameters:
     shownav: 'true'


### PR DESCRIPTION
## Description des changements

* Mise à jour des dépendances vers FRCore 2.1.0,’annuaire 1.1.0 et dernier package des terminologies


## Preview

https://ansforge.github.io/IG-fhir-cercle-de-soins/nr-update-deps/ig