### PR TITLE
Préparation de la release 2.0.1

### DIFF
--- a/.github/workflows/fhir-release.yml
+++ b/.github/workflows/fhir-release.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v3
         with:      
           path: igSource
-      - uses: ansforge/IG-workflows@v0.3.0
+      - uses: ansforge/IG-workflows@main
         with:      
           repo_ig: "./igSource"   
           github_page: "true"

--- a/.github/workflows/fhir-worklows.yml
+++ b/.github/workflows/fhir-worklows.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v3
         with:      
           path: igSource
-      - uses: ansforge/IG-workflows@v0.3.0
+      - uses: ansforge/IG-workflows@main
         with:      
           repo_ig: "./igSource"   
           github_page: "true"
@@ -20,4 +20,3 @@ jobs:
           validator_cli: "false"
           generate_testscript: "false"
           generate_plantuml : "false"
-          generate_mapping_plantuml : "false"

--- a/publication-request.json
+++ b/publication-request.json
@@ -1,11 +1,11 @@
 {
     "package-id" : "ans.fhir.fr.cds",
-    "version" :  "2.0.0",
-    "path" : "https://interop.esante.gouv.fr/ig/fhir/cds/2.0.0",
+    "version" :  "2.0.1",
+    "path" : "https://interop.esante.gouv.fr/ig/fhir/cds/2.0.1",
     "mode" : "milestone",
     "status" : "release",
     "sequence" : "trial-use",
-    "desc" : "Publication 2.0.0 du guide d'implémentation cercle de soins",
+    "desc" : "Publication 2.0.1 du guide d'implémentation cercle de soins",
     "descmd": "@release-notes.md",
     "title": "Cercle De Soins",
     "ci-build" : "https://ansforge.github.io/IG-fhir-mesures-de-sante/main/ig"

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,5 +1,6 @@
-**Release 2.0.0 de l'Implementation Guide Cercles de Soins.**
+**Release 2.0.1 de l'Implementation Guide Cercles de Soins.**
 
-[Modifications apportées dans cette release](https://github.com/ansforge/IG-fhir-cercle-de-soins/pulls?q=is%3Apr+is%3Aclosed+milestone%3A2.0.0) :
+[Modifications apportées dans cette release](https://github.com/ansforge/IG-fhir-cercle-de-soins/pulls?q=is%3Apr+is%3Aclosed+milestone%3A2.0.1) :
 
-- Pas de modifications apportées depuis la concertation
+- Mise à jour des diagrammes : passage au format plantUML et correction de liens erronés vers les profils [#46](https://github.com/ansforge/IG-fhir-cercle-de-soins/pull/46) [#47](https://github.com/ansforge/IG-fhir-cercle-de-soins/pull/47)
+- Mise à jour des dépendances FRCore, annuaire, et package terminologies [#45](https://github.com/ansforge/IG-fhir-cercle-de-soins/pull/45)

--- a/release-notes.md
+++ b/release-notes.md
@@ -2,5 +2,7 @@
 
 [Modifications apportées dans cette release](https://github.com/ansforge/IG-fhir-cercle-de-soins/pulls?q=is%3Apr+is%3Aclosed+milestone%3A2.0.1) :
 
+Release corrective
+
 - Mise à jour des diagrammes : passage au format plantUML et correction de liens erronés vers les profils [#46](https://github.com/ansforge/IG-fhir-cercle-de-soins/pull/46) [#47](https://github.com/ansforge/IG-fhir-cercle-de-soins/pull/47)
 - Mise à jour des dépendances FRCore, annuaire, et package terminologies [#45](https://github.com/ansforge/IG-fhir-cercle-de-soins/pull/45)

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -12,7 +12,7 @@ version: 2.0.0 # shall conforms to Semantic Versioning https://fr.wiktionary.org
 fhirVersion: 4.0.1
 copyrightYear: 2020+
 # releaseLabel: trial-use
-releaseLabel: working
+releaseLabel: final-text
 jurisdiction: urn:iso:std:iso:3166#FR "FRANCE"
 
 dependencies:


### PR DESCRIPTION
## Description des changements

* MAJ des GH workflows de publication
* Préparation du sushi-config, publication-request et release-notes

## Preview

https://ansforge.github.io/IG-fhir-cercle-de-soins/nr-prepare-release-2.0.1/ig