### PR TITLE
feat: passage en container_mode avec image fhir-ig-builder

### DIFF
--- a/.github/workflows/fhir-worklows.yml
+++ b/.github/workflows/fhir-worklows.yml
@@ -2,21 +2,26 @@ name: Workflow Sushi Tests gitHubpages
 on:
   workflow_call:
   push:
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 jobs:
   run-sushi-tests_gitHubPages:
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/ansforge/fhir-ig-builder:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v3
-        with:      
+        with:
           path: igSource
       - uses: ansforge/IG-workflows@main
-        with:      
-          repo_ig: "./igSource"   
+        with:
+          repo_ig: "./igSource"
           github_page: "true"
           github_page_token: ${{ secrets.GITHUB_TOKEN }}
           bake: "false"
           validator_cli: "false"
           generate_testscript: "false"
-          generate_plantuml : "false"
+          generate_plantuml: "false"
+          container_mode: "true"

--- a/.github/workflows/fhir-worklows.yml
+++ b/.github/workflows/fhir-worklows.yml
@@ -8,9 +8,6 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/ansforge/fhir-ig-builder:latest
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
## Description des changements

* Passage du workflow en `container_mode` : le job s'exécute directement dans l'image Docker pré-construite `ghcr.io/ansforge/fhir-ig-builder:latest`
* Suppression des steps d'installation des outils (Java, Node, Ruby, Jekyll) — déjà présents dans l'image
* Ajout du `container:` directive au niveau du job

## Type de changement

- [ ] Nouveau contenu (profil, extension, page, exemple)
- [ ] Correction (erreur dans un profil, une page, une dépendance)
- [ ] Refactoring (pas de changement fonctionnel)
- [x] Release

## Checklist

- [ ] `sushi-config.yaml` : `releaseLabel` est bien `ci-build` pour une version en développement
- [ ] `change-log.md` mis à jour
- [ ] La branche est à jour avec `main`

## Preview

https://ansforge.github.io/IG-fhir-cercle-de-soins/feat/container-mode/ig